### PR TITLE
Allow external hosts to request the proxy

### DIFF
--- a/Classes/Middleware/TileProxyMiddleware.php
+++ b/Classes/Middleware/TileProxyMiddleware.php
@@ -74,15 +74,27 @@ class TileProxyMiddleware implements MiddlewareInterface
         }
         return null;
     }
-    
+
     protected function fulfilsHostRestrictions(): bool
     {
         $referrer = @$_SERVER['HTTP_REFERER'];
         $host = @$_SERVER['HTTP_HOST'];
         if(empty($referrer) || empty($host)) return false;
         $referrerPieces = parse_url($referrer);
-        $referrerDomain = $this->getHostname($referrerPieces["host"] ?? '');
+        $referrerDomain = $this->getHostname($referrerPieces["host"]);
         $hostDomain = $this->getHostname($host);
-        return $referrerDomain == $hostDomain;
+        $allowedDomainsList = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tile_proxy']['allowedDomains'] ?? '';
+        $allowedDomains = GeneralUtility::trimExplode(',', $allowedDomainsList, true);
+        if ($referrerDomain == $hostDomain) {
+            return true;
+        }
+
+        foreach ($allowedDomains as $allowedDomain) {
+            $allowedDomain = $this->getHostname($allowedDomain);
+            if ($referrerDomain == $allowedDomain) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Classes/Records/RequestCacheRecordRepository.php
+++ b/Classes/Records/RequestCacheRecordRepository.php
@@ -36,7 +36,7 @@ class RequestCacheRecordRepository extends BaseRecordRepository implements Singl
 
         /** @phpstan-ignore-next-line */
         return $queryBuilder
-          ->execute()
+          ->executeQuery()
           ->fetchAssociative();
     }
 
@@ -62,7 +62,7 @@ class RequestCacheRecordRepository extends BaseRecordRepository implements Singl
             'data' => $data,
             'created' => time()
           ])
-          ->execute();
+          ->executeStatement();
     }
 
     public function deleteRecordsOlderThan(int $time): void

--- a/Configuration/FlexForms/NominatimProxy.xml
+++ b/Configuration/FlexForms/NominatimProxy.xml
@@ -14,6 +14,17 @@
                             <default>1209600</default>
                         </config>
                     </settings.cacheTime>
+                    <settings.allowedReferrerDomains>
+                        <label>LLL:EXT:tile_proxy/Resources/Private/Language/locallang.xlf:tx_tileproxy_flexform.settings.allowedReferrerDomains</label>
+                        <description>LLL:EXT:tile_proxy/Resources/Private/Language/locallang.xlf:tx_tileproxy_flexform.settings.allowedReferrerDomains.description</description>
+                        <config>
+                            <type>input</type>
+                            <eval>trim</eval>
+                            <size>30</size>
+                            <max>255</max>
+                            <placeholder>example.com,api.example.com</placeholder>
+                        </config>
+                    </settings.allowedReferrerDomains>
                 </el>
             </ROOT>
         </sDEF>

--- a/Configuration/FlexForms/TileProxy.xml
+++ b/Configuration/FlexForms/TileProxy.xml
@@ -67,6 +67,17 @@
                             <default>31536000</default>
                         </config>
                     </settings.cacheTime>
+                    <settings.allowedReferrerDomains>
+                        <label>LLL:EXT:tile_proxy/Resources/Private/Language/locallang.xlf:tx_tileproxy_flexform.settings.allowedReferrerDomains</label>
+                        <description>LLL:EXT:tile_proxy/Resources/Private/Language/locallang.xlf:tx_tileproxy_flexform.settings.allowedReferrerDomains.description</description>
+                        <config>
+                            <type>input</type>
+                            <eval>trim</eval>
+                            <size>30</size>
+                            <max>255</max>
+                            <placeholder>example.com,api.example.com</placeholder>
+                        </config>
+                    </settings.allowedReferrerDomains>
                 </el>
             </ROOT>
         </sDEF>

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -43,7 +43,7 @@ Path to empty tile png (absolute)
 If an image outside the defined bounding box is requested, a standard image is returned.
 Here you can define a path to an alternative image.
 
-Allowed domains to request proxy (absolute)
+Allowed domains to request proxy (comma separated)
 -------------------
 
 If an external domain request the proxy, you can define a list of allowed domains here.

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -43,8 +43,12 @@ Path to empty tile png (absolute)
 If an image outside the defined bounding box is requested, a standard image is returned.
 Here you can define a path to an alternative image.
 
-Allowed domains to request proxy (comma separated)
+
+Globally allowed referrer domains to request proxy (comma separated)
 -------------------
 
-If an external domain request the proxy, you can define a list of allowed domains here.
-It's helpful for headless TYPO3 installations, where the frontend and backend are on different domains.
+If an external domain request the proxy, you can define a list of globally allowed referrer domains here.
+It's helpful for headless TYPO3 installations, where the frontend and backend are on different domains
+and you want to configure it by environment variables.
+This config is a fallback for the allowed referrer domains configured in the page settings of the endpoint.
+If domains in the config of the page settings, this config won't be used.

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -42,3 +42,9 @@ Path to empty tile png (absolute)
 
 If an image outside the defined bounding box is requested, a standard image is returned.
 Here you can define a path to an alternative image.
+
+Allowed domains to request proxy (absolute)
+-------------------
+
+If an external domain request the proxy, you can define a list of allowed domains here.
+It's helpful for headless TYPO3 installations, where the frontend and backend are on different domains.

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -67,6 +67,12 @@ Each tile is stored as an image on your server.
 This time indicates on the one hand how long this image is not updated again by a request to OpenStreetMap,
 on the other hand this time is sent as caching time to the client for each tile.
 
+Additional allowed domains
+~~~~~~~~~~
+
+If an external domain requests the proxy, you can define a list of allowed referrer domains here.
+In case this is not configured the settings from the extension configuration are used.
+
 
 Nominatim Proxy Endpoint
 ----------
@@ -78,3 +84,9 @@ Caching Time (in s) for each request
 
 Each request to nominatim is stored in the database.
 This time in seconds determines how long the entry is valid and remains stored.
+
+Additional allowed domains
+~~~~~~~~~~
+
+If an external domain requests the proxy, you can define a list of allowed referrer domains here.
+In case this is not configured the settings from the extension configuration are used.

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -50,7 +50,7 @@ If the tile must be loaded and is not cached, this request will be mapped to:
     https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
 
 
-The http referrer must be your own domain or localhost, otherwise you will receive error 1001.
+The http referrer must be your own domain, localhost or configured in page settings or extension configuration, otherwise you will receive error 1001.
 
 
 Leaflet Example
@@ -117,4 +117,4 @@ If the request must be loaded and is not cached, this request will be mapped to:
     https://nominatim.openstreetmap.org/search?q=06120&format=json&addressdetails=1
 
 
-The http referrer must be your own domain or localhost, otherwise you will receive error 1001.
+The http referrer must be your own domain, localhost or configured in page settings or extension configuration, otherwise you will receive error 1001.

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -37,6 +37,12 @@
 			<trans-unit id="tx_tileproxy_flexform.settings.yes">
 				<source>Yes</source>
 			</trans-unit>
+			<trans-unit id="tx_tileproxy_flexform.settings.allowedReferrerDomains">
+				<source>Additional allowed domains</source>
+			</trans-unit>
+			<trans-unit id="tx_tileproxy_flexform.settings.allowedReferrerDomains.description">
+				<source>Additional allowed domains to request this endpoint. Write them seperated by comma.</source>
+			</trans-unit>
 			<trans-unit id="cacheinfo">
 				<source>Size: %s, Files: %s</source>
 			</trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -14,4 +14,7 @@ maxTileFileCacheSizeMb = 120
 errorTilePath = 
 
 # cat=basic; type=string; label=Path to empty tile png (absolute)
-emptyTilePath = 
+emptyTilePath =
+
+# cat=basic; type=string; label=Allowed domains to request proxy (comma separated)
+allowedDomains =

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -18,3 +18,6 @@ emptyTilePath =
 
 # cat=basic; type=string; label=Allowed domains to request proxy (comma separated)
 allowedDomains =
+
+# cat=basic; type=string; label=Globally allowed referrer domains to request proxy (comma separated)
+allowedReferrerDomains =


### PR DESCRIPTION
In the case that a headless installation of TYPO3 is used, there are often different domains for the TYPO3 backend and frontend.In this scenario the referrer does not match the host. In order to still allow the frontend to use the proxy, I have added a configuration of additional allowed domains. This means that anyone can allow additional domains to use the proxy in the future.

Can this please also be published as a new version of v1.2.8 so that it can still be used for TYPO3 v11.5?