### PR TITLE
Use GeneralUtility to create cached files

### DIFF
--- a/Classes/Controller/TileProxyController.php
+++ b/Classes/Controller/TileProxyController.php
@@ -216,12 +216,11 @@ class TileProxyController extends ProxyController
     private function loadTileAndCacheIt(string $tileURL, string $cacheTileFile): bool
     {
         if (!file_exists(dirname($cacheTileFile))) {
-            @mkdir(dirname($cacheTileFile), 0777, true);
+            GeneralUtility::mkdir_deep(dirname($cacheTileFile));
         }
         $data = $this->loadTile($tileURL);
         if ($data) {
-            file_put_contents($cacheTileFile, $data);
-            return true;
+            return GeneralUtility::writeFile($cacheTileFile, $data);
         }
 
         return false;


### PR DESCRIPTION
This PR changes the TileProxyController to use the Typo3 GeneralUtility to create the cache directory and files instead of the php mkdir and file_put_contents functions.
With that it also respects the values set in e.g. `$GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask']`.